### PR TITLE
[gem] pinning nokogiri in gemspec

### DIFF
--- a/deb-s3.gemspec
+++ b/deb-s3.gemspec
@@ -14,8 +14,9 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|bin/|ext/|lib/)} }
 
-  gem.add_dependency "thor",    "~> 0.18.0"
-  gem.add_dependency "aws-sdk", "~> 1.18"
+  gem.add_runtime_dependency "thor",    "~> 0.18.0"
+  gem.add_runtime_dependency "aws-sdk", "~> 1.18"
+  gem.add_runtime_dependency "nokogiri", "~> 1.9.0"
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "rake"
 end


### PR DESCRIPTION
Nokogiri dropped support for ruby <`2.3.0`, let's pin to more backward-compatible friendly version. Also, let's fix dep definition in the gemspec a little bit.